### PR TITLE
Pin golang image version to track base image updates over time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest
+FROM golang:1.15.0
 
 ARG USERNAME=gopher
 ARG USER_UID=1000


### PR DESCRIPTION
Enables dev images to track golang versions. The idea is that dependabot will now be configured to update the Dockerfile as golang base image version changes and dev-golang image can be pushed and tagged with specific version and latest.